### PR TITLE
ci: run lsp-bench 0.3.3 so the file-ops lifecycle actually executes

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -32,18 +32,24 @@ jobs:
         run: timeout 25m cargo test --release
 
       - name: Install lsp-bench
-        run: cargo install lsp-bench --version 0.2.7 --locked
+        run: cargo install lsp-bench --version 0.3.3 --locked
+
+      # lsp-bench --verify reports "0/0 expectations passed" and exits 0 when the
+      # server never answers, so a binary that builds but dies on startup would
+      # sail through both steps below. Check it runs before relying on them.
+      - name: Smoke-check the server binary
+        run: ./target/release/solidity-language-server --version
 
       - name: Run lsp-bench verify
         run: |
-          lsp-bench \
+          timeout 10m lsp-bench \
             -c benchmarks/ci-verify.yaml \
             -s benchmarks/servers.ci.yaml \
             --verify
 
       - name: Run lsp-bench workspace file-ops
         run: |
-          lsp-bench \
+          timeout 10m lsp-bench \
             -c benchmarks/ci-file-ops-verify.yaml \
             -s benchmarks/servers.ci.yaml \
             --verify

--- a/benchmarks/ci-file-ops-verify.yaml
+++ b/benchmarks/ci-file-ops-verify.yaml
@@ -21,19 +21,44 @@ benchmarks:
   - workspace/willCreateFiles
   - workspace/willDeleteFiles
   - workspace/willRenameFiles
+  - textDocument/documentSymbol
 
 methods:
+  # Scaffolding is delivered as an outbound workspace/applyEdit, so the
+  # willCreateFiles response itself is null — nothing to assert here beyond
+  # the request completing.
   workspace/willCreateFiles:
     createFiles:
       - file: CIFileOpsCreate.sol
 
+  # Nothing in example/ imports B.sol, so a correct server returns no edits.
   workspace/willDeleteFiles:
     deleteFiles:
       - file: B.sol
 
+  # A.sol is imported by Alias.sol, B.sol, Shop.sol and StringCompletions.sol,
+  # and the round-trip exercises the re-index between the two renames.
+  #
+  # No `expect:` here on purpose. lsp-bench 0.3.3 ignores per-step `expect`
+  # blocks inside `renameFiles`, and a method-level `minCount` counts array
+  # items, which a WorkspaceEdit response is not — it fails with
+  # "expected >= 4 but got 0". So these three steps drive the lifecycle; the
+  # documentSymbol expectation below is the part --verify evaluates.
+  #
+  # What none of it catches: a server that fails to start. lsp-bench reports
+  # "verify 0/0 expectations passed" and exits 0 when nothing answered, so
+  # liveness is checked in the workflow instead, before these steps run.
   workspace/willRenameFiles:
     renameFiles:
       - file: A.sol
         newName: AA.sol
       - file: AA.sol
         newName: A.sol
+
+  # The one assertion --verify actually evaluates here. documentSymbol returns
+  # an array, so `minCount` applies; A.sol holds a contract plus its members.
+  # This runs after the rename round-trip has restored A.sol, so it also
+  # catches a lifecycle that corrupted the file it was supposed to put back.
+  textDocument/documentSymbol:
+    expect:
+      minCount: 2

--- a/benchmarks/poolmanager-t-diag.yaml
+++ b/benchmarks/poolmanager-t-diag.yaml
@@ -1,5 +1,12 @@
 # PoolManager.t.sol — diagnostics-only benchmark
 #   lsp-bench -c benchmarks/poolmanager-t-diag.yaml
+#
+# WARNING: under lsp-bench 0.3.3 the captured `response` for
+# textDocument/diagnostic is the first inbound notification — typically
+# `{"message": "lsp server initialized.", "type": 3}` — rather than the
+# publishDiagnostics payload that 0.2.7 recorded. Timings are still valid;
+# the recorded response is not, so do not publish a diagnostics report from
+# this config until lsp-bench waits for textDocument/publishDiagnostics.
 
 project: v4-core
 file: test/PoolManager.t.sol

--- a/benchmarks/servers.yaml
+++ b/benchmarks/servers.yaml
@@ -9,6 +9,8 @@ mmsaki:
   cmd: solidity-language-server
   link: https://github.com/asyncswap/solidity-language-server
   versions:
+    # The pinned v0.1.17–v0.1.24 entries below resolve against a local
+    # ~/.solidity-lsp install and only work on a machine that has them.
     v0.1.17:
       cmd: /Users/meek/.solidity-lsp/0.1.17/bin/solidity-language-server
     v0.1.19:
@@ -23,10 +25,15 @@ mmsaki:
       cmd: /Users/meek/.solidity-lsp/0.1.23/bin/solidity-language-server
     v0.1.24:
       cmd: /Users/meek/.solidity-lsp/0.1.24/bin/solidity-language-server
+    # Stale: this points at whatever is built in the checkout, not at v0.1.25,
+    # so the commented-out A/B in pool.yaml and shop.yaml compares a build
+    # against itself. Repoint it at a real v0.1.25 install or drop it.
     v0.1.25:
       cmd: ./target/release/solidity-language-server
+    # Resolved relative to the repo root, so `latest` means "the build in this
+    # checkout" for whoever is running the benchmark.
     latest:
-      cmd: /Users/meek/developer/asyncswap/solidity-language-server/target/release/solidity-language-server
+      cmd: ./target/release/solidity-language-server
 
 solc:
   cmd: solc


### PR DESCRIPTION
`556208f` renamed the benchmark keys to lsp-bench 0.3.x spellings (`renameSteps` → `renameFiles` and friends), but preflight still installs 0.2.7, which doesn't know them.

It fails quietly rather than loudly. 0.2.7 declares the field as `#[serde(default, rename = "renameSteps")]` with no `deny_unknown_fields`, so the blocks are dropped and it falls back to one shot against the top-level `file:` with a placeholder name. The step has been running *a* rename, just not the configured one — so the `A.sol → AA.sol → A.sol` round-trip, which exists to catch stale caches on the second rename, hasn't run since May.

Ran both locally against this checkout:

```
0.2.7  [1/3] workspace/willRenameFiles          (one-shot, placeholder name)

0.3.3  [1/3] workspace/willRenameFiles
       rename 2 rename step(s) (full lifecycle)
       → 4 file(s) with edits
       → 4 file(s) with edits
```

While testing this I found something worth flagging separately: `--verify` doesn't catch a dead server. Pointed at a stub that exits immediately, *both* CI configs print `verify 0/0 expectations passed` and exit 0 — lsp-bench treats "nothing answered" as "nothing to check". A binary that builds but dies on startup passes preflight today, before and after this bump. So the workflow now runs `--version` first, and both lsp-bench steps get the `timeout` wrapper the `cargo test` step above them already has.

`ci-file-ops-verify.yaml` also gets a `documentSymbol` expectation, since that's something `--verify` can actually evaluate here — the file-op responses are `WorkspaceEdit`s, and lsp-bench ignores per-step `expect` blocks while a method-level `minCount` counts array items.

One regression from the bump, which I've disclosed rather than fixed: 0.3.3 records the first inbound notification as the `textDocument/diagnostic` response — usually `{"message": "lsp server initialized."}` — where 0.2.7 recorded the publishDiagnostics payload. Timings are still valid, the captured response isn't, so `poolmanager-t-diag.yaml` gets a warning comment. Probably worth an upstream issue.

Also fixes `servers.yaml`: the `latest` entry pointed at an absolute path under someone's home directory, so comparison runs resolved to a nonexistent binary for everyone else. Happy to split that out if you'd rather keep the CI pin isolated.

Both CI configs exit 0 under 0.3.3 and `example/` is left untouched.
